### PR TITLE
Remove checking access on every field view

### DIFF
--- a/app/views/application/_show_active_record_field.html.haml
+++ b/app/views/application/_show_active_record_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %strong= "models.fields.#{controller.resource_name.singularize}.#{column}".tc
-  = link_to value, [controller.controller_namespace, value].flatten
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+= link_to value, [controller.controller_namespace, value].flatten

--- a/app/views/application/_show_boolean_field.html.haml
+++ b/app/views/application/_show_boolean_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %input{type: :checkbox, readonly: true, checked: value}
-  %label= "#{controller.resource_name.singularize}.#{column}".tmf
+%input{type: :checkbox, readonly: true, checked: value}
+%label= "#{controller.resource_name.singularize}.#{column}".tmf

--- a/app/views/application/_show_date_field.html.haml
+++ b/app/views/application/_show_date_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %strong= "#{controller.resource_name.singularize}.#{column}".tmfc
-  = value.l
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+= value.l

--- a/app/views/application/_show_datetime_field.html.haml
+++ b/app/views/application/_show_datetime_field.html.haml
@@ -1,6 +1,5 @@
-- if can? :view, resource, column
-  %strong= "#{controller.resource_name.singularize}.#{column}".tmfc
-  - if value.present?
-    = value.l
-  - else
-    Non définie
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+- if value.present?
+  = value.l
+- else
+  = 'errors.value.undefined'.t

--- a/app/views/application/_show_default_field.html.haml
+++ b/app/views/application/_show_default_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %strong= "models.fields.#{controller.resource_name.singularize}.#{column}".tc
-  = value.respond_to?(:to_sentence) ? value.select(&:present?).to_sentence : value
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+= value.respond_to?(:to_sentence) ? value.select(&:present?).to_sentence : value

--- a/app/views/application/_show_email_field.html.haml
+++ b/app/views/application/_show_email_field.html.haml
@@ -1,2 +1,2 @@
-%strong= "models.fields.#{controller.resource_name.singularize}.#{column}".tc
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
 = link_to value, "mailto:#{value}"

--- a/app/views/application/_show_email_field.html.haml
+++ b/app/views/application/_show_email_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %strong= "models.fields.#{controller.resource_name.singularize}.#{column}".tc
-  = link_to value, "mailto:#{value}"
+%strong= "models.fields.#{controller.resource_name.singularize}.#{column}".tc
+= link_to value, "mailto:#{value}"

--- a/app/views/application/_show_image_field.html.haml
+++ b/app/views/application/_show_image_field.html.haml
@@ -1,9 +1,8 @@
-- if can? :view, resource, column
-  - if value.class == PdfUploader
-    %strong= "#{controller.resource_name.singularize}.#{column}".tmfc
-    = link_to value.url do
-      = icon 'file-pdf-o'
-      = value
-  - elsif value.respond_to?(:thumb)
-    %strong= "#{controller.resource_name.singularize}.#{column}".tmf
-    = image_tag(value.thumb)
+- if value.class == PdfUploader
+  %strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+  = link_to value.url do
+    = icon 'file-pdf-o'
+    = value
+- elsif value.respond_to?(:thumb)
+  %strong= "#{controller.resource_name.singularize}.#{column}".tmf
+  = image_tag(value.thumb)

--- a/app/views/application/_show_integer_field.html.haml
+++ b/app/views/application/_show_integer_field.html.haml
@@ -1,6 +1,8 @@
-- if can? :view, resource, column
-  %strong= "#{controller.resource_name.singularize}.#{column}".tmfc
-  - if controller.resource_class.respond_to?(column.to_s.pluralize)
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+- if controller.resource_class.respond_to?(column.to_s.pluralize)
+  - if value.present?
     = "enums.#{controller.resource_name.singularize}.#{column}.#{value}".t
   - else
-    = value
+    = 'errors.value.undefined'.t
+- else
+  = value

--- a/app/views/application/_show_json_field.html.haml
+++ b/app/views/application/_show_json_field.html.haml
@@ -1,8 +1,7 @@
-- if can? :view, resource, column
-  %strong= "#{controller.resource_name.singularize}.#{column}".tmf
-  - if value.present?
-    %pre
-      %code.json= JSON.pretty_generate(value)
+%strong= "#{controller.resource_name.singularize}.#{column}".tmf
+- if value.present?
+  %pre
+    %code.json= JSON.pretty_generate(value)
 
-  - else
-    Aucun paramètres
+- else
+  Aucun paramètres

--- a/app/views/application/_show_markdown_field.html.haml
+++ b/app/views/application/_show_markdown_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %strong= "#{controller.resource_name.singularize}.#{column}".tmf
-  .md-preview= markdown value
+%strong= "#{controller.resource_name.singularize}.#{column}".tmf
+.md-preview= markdown value

--- a/app/views/application/_show_phone_field.html.haml
+++ b/app/views/application/_show_phone_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %strong= "models.fields.#{controller.resource_name.singularize}.#{column}".tc
-  = link_to phone_number(value), "tel:#{value}"
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+= link_to phone_number(value), "tel:#{value}"

--- a/app/views/application/_show_text_field.html.haml
+++ b/app/views/application/_show_text_field.html.haml
@@ -1,3 +1,2 @@
-- if can? :view, resource, column
-  %strong= "#{controller.resource_name.singularize}.#{column}".tmfc
-  .md-preview= value
+%strong= "#{controller.resource_name.singularize}.#{column}".tmfc
+.md-preview= value

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -37,6 +37,8 @@ fr:
     not_found:
       title: "Erreur 404"
       content: "La page demandée n'existe pas"
+    value:
+      undefined: Non définie
 
   roles:
     admin: Admin


### PR DESCRIPTION
I removed every can? assertion on model fields. 
It's already tested (https://github.com/3print/boilerplate/blob/update-view-fields/app/views/application/_show.html.haml#L7)[here] and it does not seems it's been used even once.
The idea is good, we shall keep in mind that we have a `can?` method for when we want to narrow some fields

Use tmfc instead of tc for model fields
Fallback enum to undefined when value is not set

Any though ?